### PR TITLE
#9: Setup Dependency Injection on the Server

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +498,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,9 +527,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1044,6 +1063,8 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "shaku",
+ "shaku_actix",
 ]
 
 [[package]]
@@ -1055,6 +1076,39 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shaku"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334da76925a094e2c72802ce17433cba4b5d8661d66ef36e1f899efab17192a5"
+dependencies = [
+ "anymap",
+ "once_cell",
+ "shaku_derive",
+]
+
+[[package]]
+name = "shaku_actix"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bf94dfba474de32f1cbacecced756c6c22ba1b20522bd1e2e8c0a4377a1557"
+dependencies = [
+ "actix-web",
+ "futures-util",
+ "shaku",
+]
+
+[[package]]
+name = "shaku_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524f791f1f958b9c1825c1e48657d3bc485ee9ac4a1c7c226ab7fc7010afa7dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,3 +11,5 @@ no-panic = "0.1.22"
 openssl = { version = "0.10.52", features = ["v111"] }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
+shaku = "0.6.1"
+shaku_actix = "0.2.0"

--- a/server/README.md
+++ b/server/README.md
@@ -33,4 +33,4 @@ The repository contains a self-signed SSL/TLS certificate for **DEVELOPMENT PURP
 <br />
 **shaku** - A compile time dependency injection framework for Rust.
 <br />
-**shaku_actix** - An integration between shaku and Actix Web.
+**shaku_actix** - An integration between `shaku` and `actix-web`.

--- a/server/README.md
+++ b/server/README.md
@@ -30,3 +30,7 @@ The repository contains a self-signed SSL/TLS certificate for **DEVELOPMENT PURP
 **serde** - A framework for serializing and deserializing Rust data structures.
 <br />
 **serde_json** - A JSON extension for `serde`.
+<br />
+**shaku** - A compile time dependency injection framework for Rust.
+<br />
+**shaku_actix** - An integration between shaku and Actix Web.

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -37,7 +37,7 @@ pub(crate) struct HttpConfig {
     pub(crate) certificate_key_path: String,
 }
 
-/// The Config implementation.
+/// An implementation for the Config struct.
 impl Config {
     /// # Description
     ///

--- a/server/src/injector.rs
+++ b/server/src/injector.rs
@@ -1,8 +1,6 @@
-use std::error::Error;
-
-use shaku::module;
-
 use crate::config::Config;
+use shaku::module;
+use std::error::Error;
 
 // Create the dependency injector module.
 module! {

--- a/server/src/injector.rs
+++ b/server/src/injector.rs
@@ -1,0 +1,38 @@
+use std::error::Error;
+
+use shaku::module;
+
+use crate::config::Config;
+
+// Create the dependency injector module.
+module! {
+    pub(crate) DependencyInjector {
+        components = [],
+        providers = []
+    }
+}
+
+// An implementation for the DependencyInjector struct.
+impl DependencyInjector {
+    /// # Description
+    ///
+    /// Create a dependency injector from the server's configuration.
+    ///
+    /// # Arguments
+    ///
+    /// `config` - The configuration that will be used to create the dependency injector.
+    ///
+    /// # Returns
+    ///
+    /// This method returns a result:
+    /// - The Ok variant will be returned with the injector, if it was successfully created.
+    /// - The Err variant will be returned with an error, if an error occurs while attempting to
+    /// create the injector.
+    pub(crate) async fn create_from_config(_config: &Config) -> Result<Self, Box<dyn Error>> {
+        // Create the injector.
+        let injector: DependencyInjector = DependencyInjector::builder().build();
+
+        // Return the injector.
+        return Ok(injector);
+    }
+}


### PR DESCRIPTION
- Installed shaku.
- Installed shaku_actix.
- Added the new dependencies to the server's `README.md`.
- Created a dependency injection module and added it to the application data.